### PR TITLE
BH-6804 Cache the JWT in the provided cache adapter 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ install: composer install
 script:
   - vendor/bin/phpcs
   - vendor/bin/phpunit --coverage-clover=coverage.xml
+before_script:
+  - echo "xdebug.mode=coverage" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,12 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.1",
+        "ext-json": "*",
+        "psr/cache": "^1.0",
         "psr/log": "^1.1",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
+        "cache/adapter-common": "^1.2",
         "fig/http-message-util": "^1.1",
         "guzzlehttp/psr7": "^1.6",
         "netresearch/jsonmapper": "^3.1"


### PR DESCRIPTION
If there is a provided cache adapter, use it to store the JWT for longer than one request.