### PR TITLE
feature/NGMA-430-Jwt-refresh

### DIFF
--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -257,8 +257,8 @@ class BrighteApi
      */
     private function decodeToken(string $token): \stdClass
     {
-        list($header, $payload, $signature) = explode(".", $token);
+        $tokenPayload = explode(".", $token)[1];
 
-        return json_decode(base64_decode($payload));
+        return json_decode(base64_decode($tokenPayload));
     }
 }

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -33,6 +33,12 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
     /** @var \BrighteCapital\Api\BrighteApi */
     protected $api;
 
+    /** @var string */
+    protected $accessToken;
+
+    /** @var string */
+    protected $accessTokenExpired;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -45,6 +51,37 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->cache = $this->createMock(CacheItemPoolInterface::class);
         $this->api = new BrighteApi($this->http, $this->logger, $config, $this->cache);
+
+        $tokenHeader = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+        $tokenSignature = 'vSOe9pC7ex0LwD5KM9_kp_jrXFLoTTKfvy959tHtU5g';
+
+        $tokenPayload = [
+            'userId' => '6',
+            'remoteId' => 'U15',
+            'firstName' => 'Andy',
+            'lastName' => 'Fake',
+            'email' => 'vendor@brighte.com.au',
+            'mobile' => '0400000044',
+            'role' => 'VENDOR',
+            'roleId' => 3,
+            'scope' => ["create:notifications"],
+            'vendors' => [3, 7],
+            'agent' => null,
+            'iat' => 1639434967,
+            'exp' => 1639434967,
+            'aud' => 'https://brighte.com.au',
+            'iss' => 'Brighte'
+        ];
+
+        $tokenPayloadEncoded = base64_encode(json_encode($tokenPayload, JSON_UNESCAPED_SLASHES));
+
+        $this->accessTokenExpired = $tokenHeader . '.' . $tokenPayloadEncoded . '.' . $tokenSignature;
+
+        $tokenPayload['exp'] = time() + 60;
+
+        $tokenPayloadEncoded = base64_encode(json_encode($tokenPayload, JSON_UNESCAPED_SLASHES));
+
+        $this->accessToken = $tokenHeader . '.' . $tokenPayloadEncoded . '.' . $tokenSignature;
     }
 
     /**
@@ -55,10 +92,10 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::doRequest
      * @covers ::authenticate
      * @covers ::getToken
+     * @group nick
      */
     public function testGet(): void
     {
-        $accessToken = 'SLf:$*h$5fpj(#*pa';
         $expectApiRequest = new Request(
             'GET',
             new Uri('https://api.brighte.com.au/v1/chipmonks?size=0.5'),
@@ -66,30 +103,133 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
                 'extra-header' => 'extra-header',
-                'Authorization' => 'Bearer ' . $accessToken,
+                'Authorization' => 'Bearer ' . $this->accessToken,
             ]
         );
         $this->cache->expects(self::once())->method('save');
-        $authResponse = new Response(200, [], json_encode(['access_token' => $accessToken, 'expires_in' => 900]));
+        $authResponse = new Response(200, [], json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]));
         $apiResponse = new Response(200, [], 'Sample Response');
-        $this->http->expects(self::exactly(3))->method('sendRequest')
+        $apiFailResponse = new Response(401, [], 'Sample Response');
+        $this->http->expects(self::exactly(5))->method('sendRequest')
             ->withConsecutive([self::isInstanceOf(Request::class)], [$expectApiRequest])
-            ->willReturnOnConsecutiveCalls($authResponse, $apiResponse, $apiResponse);
+            ->willReturnOnConsecutiveCalls($authResponse, $apiResponse, $apiResponse, $apiFailResponse, $authResponse);
         // Authenticate, fill cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
         );
+
+        $this->assertEquals('200', $result->getStatusCode());
+
         // Use cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
         );
+
+        $this->assertEquals('200', $result->getStatusCode());
+
         // Use existing auth, get fresh
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $this->api->get('/dangermouse', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/dangermouse', 'size=0.5', ['extra-header' => 'extra-header'])
         );
+
+        $this->assertEquals('200', $result->getStatusCode());
+
+        // Use existing auth, get fresh but failed (401).
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $result = $this->api->get('/mole', 'size=0.5', ['extra-header' => 'extra-header'])
+        );
+
+        $this->assertEquals('401', $result->getStatusCode());
+
+        // Use existing auth, Using same failed resource again, but get fresh due to prior failure.
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $result = $this->api->get('/mole', 'size=0.5', ['extra-header' => 'extra-header'])
+        );
+
+        $this->assertEquals('200', $result->getStatusCode());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getCached
+     * @covers ::get
+     * @covers ::post
+     * @covers ::doRequest
+     * @covers ::authenticate
+     * @covers ::getToken
+     * @covers ::isTokenExpired
+     * @covers ::decodeToken
+     * @group nick2
+     */
+    public function testJWTExpired(): void
+    {
+        $expectApiRequestExpired = new Request(
+            'GET',
+            new Uri('https://api.brighte.com.au/v1/chipmonks?size=0.5'),
+            [
+                'accept' => 'application/json',
+                'content-type' => 'application/json',
+                'extra-header' => 'extra-header',
+                'Authorization' => 'Bearer ' . $this->accessTokenExpired,
+            ]
+        );
+
+        $expectApiRequestExpiredOther = new Request(
+            'GET',
+            new Uri('https://api.brighte.com.au/v1/dangermouse?size=0.5'),
+            [
+                'accept' => 'application/json',
+                'content-type' => 'application/json',
+                'extra-header' => 'extra-header',
+                'Authorization' => 'Bearer ' . $this->accessTokenExpired,
+            ]
+        );
+
+        $this->cache->expects(self::exactly(2))->method('save');
+        $authResponseExpired = new Response(
+            200,
+            [],
+            json_encode(['access_token' => $this->accessTokenExpired, 'expires_in' => 900]),
+        );
+        $apiResponse = new Response(200, [], 'Sample Response');
+
+        $this->http->expects(self::exactly(4))->method('sendRequest')
+            ->withConsecutive(
+                [self::isInstanceOf(Request::class)],
+                [$expectApiRequestExpired],
+                [self::isInstanceOf(Request::class)],
+                [$expectApiRequestExpiredOther]
+            )
+            ->willReturnOnConsecutiveCalls($authResponseExpired, $apiResponse, $authResponseExpired, $apiResponse);
+
+        // Authenticate, fill cache
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+        );
+
+        $this->assertEquals('200', $result->getStatusCode());
+
+        // Use cache
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+        );
+
+        $this->assertEquals('200', $result->getStatusCode());
+
+        // Use existing auth, get fresh
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $result = $this->api->get('/dangermouse', 'size=0.5', ['extra-header' => 'extra-header'])
+        );
+
+        $this->assertEquals('200', $result->getStatusCode());
     }
 
     /**
@@ -148,18 +288,17 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      */
     public function testAuthCache(): void
     {
-        $accessToken = 'SLf:$*h$5fpj(#*pa';
         $expectApiRequest = new Request(
             'GET',
             new Uri('https://api.brighte.com.au/v1/chipmonks'),
             [
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
-                'Authorization' => 'Bearer ' . $accessToken,
+                'Authorization' => 'Bearer ' . $this->accessToken,
             ]
         );
         $item = $this->createMock(CacheItemInterface::class);
-        $item->expects(self::once())->method('get')->willReturn($accessToken);
+        $item->expects(self::once())->method('get')->willReturn($this->accessToken);
         $this->cache->expects(self::once())->method('getItem')->with('service_jwt')->willReturn($item);
         $this->http->expects(self::exactly(1))->method('sendRequest')->with($expectApiRequest);
         $this->api->get('/chipmonks');
@@ -174,8 +313,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      */
     public function testPost(): void
     {
-        $accessToken = 'SLf:$*h$5fpj(#*pa';
-        $authResponse = new Response(200, [], json_encode(['access_token' => $accessToken]));
+        $authResponse = new Response(200, [], json_encode(['access_token' => $this->accessToken]));
         $apiResponse = new Response(200, [], 'Sample Response');
         $this->http->expects(self::exactly(2))->method('sendRequest')
             ->with(self::isInstanceOf(Request::class))

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -135,7 +135,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         $apiFailResponse = new Response(
             401,
             [],
-            json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]),
+            json_encode(['access_token' => $this->accessToken, 'expires_in' => 900])
         );
 
         $secondCall = $apiResponse;

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -92,7 +92,8 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::doRequest
      * @covers ::authenticate
      * @covers ::getToken
-     * @group nick
+     * @covers ::isTokenExpired
+     * @covers ::decodeToken
      */
     public function testGet(): void
     {
@@ -164,7 +165,6 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::getToken
      * @covers ::isTokenExpired
      * @covers ::decodeToken
-     * @group nick2
      */
     public function testJWTExpired(): void
     {

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -114,7 +114,6 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::isTokenExpired
      * @covers ::decodeToken
      * @dataProvider getProvider
-     * @group nick
      */
     public function testGet($url, $statusCode, $sendRequestCalled): void
     {
@@ -171,26 +170,23 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      */
     public function testJWTExpired(): void
     {
+        $uriData = [
+            'accept' => 'application/json',
+            'content-type' => 'application/json',
+            'extra-header' => 'extra-header',
+            'Authorization' => self::BEARER . $this->accessTokenExpired,
+        ];
+
         $expectApiRequestExpired = new Request(
             'GET',
             new Uri('https://api.brighte.com.au/v1/chipmonks?size=0.5'),
-            [
-                'accept' => 'application/json',
-                'content-type' => 'application/json',
-                'extra-header' => 'extra-header',
-                'Authorization' => self::BEARER . $this->accessTokenExpired,
-            ]
+            $uriData
         );
 
         $expectApiRequestExpiredOther = new Request(
             'GET',
             new Uri('https://api.brighte.com.au/v1/dangermouse?size=0.5'),
-            [
-                'accept' => 'application/json',
-                'content-type' => 'application/json',
-                'extra-header' => 'extra-header',
-                'Authorization' => self::BEARER . $this->accessTokenExpired,
-            ]
+            $uriData
         );
 
         $this->cache->expects(self::exactly(2))->method('save');
@@ -218,18 +214,10 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('200', $result->getStatusCode());
 
-        // Use cache
-        $this->assertInstanceOf(
-            ResponseInterface::class,
-            $result = $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
-        );
-
-        $this->assertEquals('200', $result->getStatusCode());
-
         // Use existing auth, get fresh
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/dangermouse', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
+            $result = $this->api->get(self::URL_DANGER_MOUSE, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -38,12 +38,12 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
     /** @var string */
     protected $accessTokenExpired;
 
-    const BEARER = 'Bearer ';
-    const SAMPLE_RESPONSE = 'Sample Response';
-    const URL_CHIPMONKS = '/chipmonks';
-    const URL_DANGER_MOUSE = '/dangermouse';
-    const URL_MOLE = '/mole';
-    const URL_PARAM_SIZE = 'size=0.5';
+    private const BEARER = 'Bearer ';
+    private const SAMPLE_RESPONSE = 'Sample Response';
+    private const URL_CHIPMONKS = '/chipmonks';
+    private const URL_DANGER_MOUSE = '/dangermouse';
+    private const URL_MOLE = '/mole';
+    private const URL_PARAM_SIZE = 'size=0.5';
 
     protected function setUp(): void
     {
@@ -132,7 +132,11 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
 
         $authResponse = new Response(200, [], json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]));
         $apiResponse = new Response(200, [], self::SAMPLE_RESPONSE);
-        $apiFailResponse = new Response(401, [], json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]));
+        $apiFailResponse = new Response(
+            401,
+            [],
+            json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]),
+        );
 
         $secondCall = $apiResponse;
         if ($statusCode !== '200') {
@@ -311,7 +315,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
             ->willReturnOnConsecutiveCalls($authResponse, $apiResponse);
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $this->api->post( self::URL_CHIPMONKS, 'body', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
+            $this->api->post(self::URL_CHIPMONKS, 'body', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
     }
 }

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -197,7 +197,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         $authResponseExpired = new Response(
             200,
             [],
-            json_encode(['access_token' => $this->accessTokenExpired, 'expires_in' => 900]),
+            json_encode(['access_token' => $this->accessTokenExpired, 'expires_in' => 900])
         );
         $apiResponse = new Response(200, [], self::SAMPLE_RESPONSE);
 

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -93,7 +93,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function testGetProvider()
+    public function getProvider()
     {
         return [
             [self::URL_CHIPMONKS, '200', 2],
@@ -113,7 +113,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::getToken
      * @covers ::isTokenExpired
      * @covers ::decodeToken
-     * @dataProvider testGetProvider
+     * @dataProvider getProvider
      * @group nick
      */
     public function testGet($url, $statusCode, $sendRequestCalled): void

--- a/tests/BrighteApiTest.php
+++ b/tests/BrighteApiTest.php
@@ -20,7 +20,6 @@ use Psr\Log\LoggerInterface;
  */
 class BrighteApiTest extends \PHPUnit\Framework\TestCase
 {
-
     /** @var \Psr\Http\Client\ClientInterface */
     protected $http;
 
@@ -38,6 +37,11 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
 
     /** @var string */
     protected $accessTokenExpired;
+
+    const BEARER = 'Bearer ';
+    const SAMPLE_RESPONSE = 'Sample Response';
+    const URL_CHIPMONKS = '/chipmonks';
+    const URL_PARAM_SIZE = 'size=0.5';
 
     protected function setUp(): void
     {
@@ -104,20 +108,20 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
                 'extra-header' => 'extra-header',
-                'Authorization' => 'Bearer ' . $this->accessToken,
+                'Authorization' => self::BEARER . $this->accessToken,
             ]
         );
         $this->cache->expects(self::once())->method('save');
         $authResponse = new Response(200, [], json_encode(['access_token' => $this->accessToken, 'expires_in' => 900]));
-        $apiResponse = new Response(200, [], 'Sample Response');
-        $apiFailResponse = new Response(401, [], 'Sample Response');
+        $apiResponse = new Response(200, [], self::SAMPLE_RESPONSE);
+        $apiFailResponse = new Response(401, [], self::SAMPLE_RESPONSE);
         $this->http->expects(self::exactly(5))->method('sendRequest')
             ->withConsecutive([self::isInstanceOf(Request::class)], [$expectApiRequest])
             ->willReturnOnConsecutiveCalls($authResponse, $apiResponse, $apiResponse, $apiFailResponse, $authResponse);
         // Authenticate, fill cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -125,7 +129,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -133,7 +137,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use existing auth, get fresh
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/dangermouse', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/dangermouse', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -141,7 +145,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use existing auth, get fresh but failed (401).
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/mole', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/mole', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('401', $result->getStatusCode());
@@ -149,7 +153,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use existing auth, Using same failed resource again, but get fresh due to prior failure.
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/mole', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/mole', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -175,7 +179,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
                 'extra-header' => 'extra-header',
-                'Authorization' => 'Bearer ' . $this->accessTokenExpired,
+                'Authorization' => self::BEARER . $this->accessTokenExpired,
             ]
         );
 
@@ -186,7 +190,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
                 'extra-header' => 'extra-header',
-                'Authorization' => 'Bearer ' . $this->accessTokenExpired,
+                'Authorization' => self::BEARER . $this->accessTokenExpired,
             ]
         );
 
@@ -196,7 +200,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
             [],
             json_encode(['access_token' => $this->accessTokenExpired, 'expires_in' => 900]),
         );
-        $apiResponse = new Response(200, [], 'Sample Response');
+        $apiResponse = new Response(200, [], self::SAMPLE_RESPONSE);
 
         $this->http->expects(self::exactly(4))->method('sendRequest')
             ->withConsecutive(
@@ -210,7 +214,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Authenticate, fill cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -218,7 +222,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use cache
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -226,7 +230,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
         // Use existing auth, get fresh
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $result = $this->api->get('/dangermouse', 'size=0.5', ['extra-header' => 'extra-header'])
+            $result = $this->api->get('/dangermouse', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
 
         $this->assertEquals('200', $result->getStatusCode());
@@ -254,7 +258,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
             ->willReturn($authResponse);
         // Authenticate but fail
         $this->expectException(\InvalidArgumentException::class);
-        $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header']);
+        $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header']);
     }
 
     /**
@@ -274,7 +278,7 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
             ->willReturn($authResponse);
         // Authenticate but fail
         $this->expectException(\InvalidArgumentException::class);
-        $this->api->get('/chipmonks', 'size=0.5', ['extra-header' => 'extra-header']);
+        $this->api->get(self::URL_CHIPMONKS, self::URL_PARAM_SIZE, ['extra-header' => 'extra-header']);
     }
 
     /**
@@ -294,14 +298,14 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
             [
                 'accept' => 'application/json',
                 'content-type' => 'application/json',
-                'Authorization' => 'Bearer ' . $this->accessToken,
+                'Authorization' => self::BEARER . $this->accessToken,
             ]
         );
         $item = $this->createMock(CacheItemInterface::class);
         $item->expects(self::once())->method('get')->willReturn($this->accessToken);
         $this->cache->expects(self::once())->method('getItem')->with('service_jwt')->willReturn($item);
         $this->http->expects(self::exactly(1))->method('sendRequest')->with($expectApiRequest);
-        $this->api->get('/chipmonks');
+        $this->api->get(self::URL_CHIPMONKS);
     }
 
     /**
@@ -314,13 +318,13 @@ class BrighteApiTest extends \PHPUnit\Framework\TestCase
     public function testPost(): void
     {
         $authResponse = new Response(200, [], json_encode(['access_token' => $this->accessToken]));
-        $apiResponse = new Response(200, [], 'Sample Response');
+        $apiResponse = new Response(200, [], self::SAMPLE_RESPONSE);
         $this->http->expects(self::exactly(2))->method('sendRequest')
             ->with(self::isInstanceOf(Request::class))
             ->willReturnOnConsecutiveCalls($authResponse, $apiResponse);
         $this->assertInstanceOf(
             ResponseInterface::class,
-            $this->api->post('/chipmonks', 'body', 'size=0.5', ['extra-header' => 'extra-header'])
+            $this->api->post( self::URL_CHIPMONKS, 'body', self::URL_PARAM_SIZE, ['extra-header' => 'extra-header'])
         );
     }
 }


### PR DESCRIPTION
- Add token to refresh if Token is expired
- Make sure expired result from API call is not cached.

Please look at ticket: https://brighte.atlassian.net/browse/NGMA-430