### PR TITLE
fix optional params

### DIFF
--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -8,6 +8,7 @@ use Cache\Adapter\Common\CacheItem;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -223,13 +224,15 @@ class BrighteApi
             $headers['Authorization'] = 'Bearer ' . $this->getToken();
         }
 
+        $path = UriResolver::removeDotSegments($this->prefix . $path);
+
         return  $this->http->sendRequest(new Request(
             $method,
             Uri::fromParts([
                 'scheme' => $this->scheme,
                 'host' => $this->host,
                 'port' => $this->port,
-                'path' => $this->prefix . $path,
+                'path' => $path,
                 'query' => $query,
             ]),
             $headers,

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -41,14 +41,15 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
         string $vendorId = null,
         int $version = null
     ): string {
-        $queryParameter = "slug: {$slug}" . PHP_EOL;
+        $queryParameter = "slug: {$slug}";
         if ($vendorId) {
-            $queryParameter .= "vendorId: \"{$vendorId}\"" . PHP_EOL;
+            $queryParameter .= PHP_EOL . "vendorId: \"{$vendorId}\"";
         }
         if ($version) {
-            $queryParameter .= "version: {$version}" . PHP_EOL;
+            $queryParameter .= PHP_EOL . "version: {$version}";
         }
-        $query = <<<GQL
+
+        return <<<GQL
             query {
                 financialProductConfiguration(
                 {$queryParameter}
@@ -73,7 +74,6 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
                 }
             }
 GQL;
-        return $query;
     }
 
     public function getFinancialProduct(string $slug): ?FinancialProduct

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -28,49 +28,39 @@ class FinanceCoreApiTest extends \PHPUnit\Framework\TestCase
     /** @var \BrighteCapital\Api\FinanceCoreApi */
     protected $financeCoreApi;
 
-    protected $expectedConfig = [
-        'establishmentFee' => 4.99,
-        'interestRate' => 5.99,
-        'applicationFee' => 6.99,
-        'annualFee' => 7.99,
-        'weeklyAccountFee' => 8.99,
-        'latePaymentFee' => 9.99,
-        'introducerFee' => 10.99,
-        'enableExpressSettlement' => true,
-        'minFinanceAmount' => 11.99,
-        'maxFinanceAmount' => 12.99,
-        'minRepaymentMonth' => 13,
-        'maxRepaymentMonth' => 30,
-        'forceCcaProcess' => true,
-        'defaultPaymentCycle' => 'weekly',
-        'invoiceRequired' => true,
-        'manualSettlementRequired' => true,
-        'version' => 1,
-    ];
+    private $expectedConfig;
 
-    private $expectedConfigResponse = [
-        'data' => [
-            'financialProductConfiguration' => [
-                'establishmentFee' => 4.99,
-                'interestRate' => 5.99,
-                'applicationFee' => 6.99,
-                'annualFee' => 7.99,
-                'weeklyAccountFee' => 8.99,
-                'latePaymentFee' => 9.99,
-                'introducerFee' => 10.99,
-                'enableExpressSettlement' => true,
-                'minFinanceAmount' => 11.99,
-                'maxFinanceAmount' => 12.99,
-                'minRepaymentMonth' => 13,
-                'maxRepaymentMonth' => 30,
-                'forceCcaProcess' => true,
-                'defaultPaymentCycle' => 'weekly',
-                'invoiceRequired' => true,
-                'manualSettlementRequired' => true,
-                'version' => 1,
-            ],
-        ]
-    ];
+    private $expectedConfigResponse;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->expectedConfig = [
+            'establishmentFee' => 4.99,
+            'interestRate' => 5.99,
+            'applicationFee' => 6.99,
+            'annualFee' => 7.99,
+            'weeklyAccountFee' => 8.99,
+            'latePaymentFee' => 9.99,
+            'introducerFee' => 10.99,
+            'enableExpressSettlement' => true,
+            'minFinanceAmount' => 11.99,
+            'maxFinanceAmount' => 12.99,
+            'minRepaymentMonth' => 13,
+            'maxRepaymentMonth' => 30,
+            'forceCcaProcess' => true,
+            'defaultPaymentCycle' => 'weekly',
+            'invoiceRequired' => true,
+            'manualSettlementRequired' => true,
+            'version' => 1,
+        ];
+
+        $this->expectedConfigResponse = [
+            'data' => [
+                'financialProductConfiguration' => $this->expectedConfig,
+            ]
+        ];
+    }
 
     protected function setUp(): void
     {

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -106,6 +106,7 @@ class FinanceCoreApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::__construct
      * @covers ::getFinancialProductConfig
      * @covers ::getFinancialProductConfigFromResponse
+     * @covers ::createGetFinancialProductConfigQuery
      * @dataProvider financialProductConfigProvider
      */
     public function testgetFinancialProductConfig($input, $response): void
@@ -215,6 +216,7 @@ GQL;
     /**
     * @covers ::__construct
     * @covers ::getFinancialProductConfig
+    * @covers ::createGetFinancialProductConfigQuery
     * @covers ::logResponse
     */
     public function testgetFinancialProductConfigFail(): void


### PR DESCRIPTION
This PR removes dots from URI path and fixes optional parameters(`vendorId` and `version`) when get financial product config from finance core