### PR TITLE
fix error handling for graphql

### DIFF
--- a/src/AbstractApi.php
+++ b/src/AbstractApi.php
@@ -44,4 +44,17 @@ abstract class AbstractApi
         );
         $this->logger->warning($message);
     }
+
+    protected function logGraphqlResponse(string $function, ResponseInterface $response): void
+    {
+        $body = json_decode((string) $response->getBody()) ?? new stdClass();
+        $message = sprintf(
+            '%s->%s: %d: %s',
+            self::class,
+            $function,
+            $response->getStatusCode(),
+            $body->errors[0]->message ?? $response->getReasonPhrase()
+        );
+        $this->logger->warning($message);
+    }
 }

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -7,10 +7,12 @@ namespace BrighteCapital\Api;
 use BrighteCapital\Api\Models\FinancialProductConfig;
 use BrighteCapital\Api\Models\FinancialProduct;
 use Fig\Http\Message\StatusCodeInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
 {
     public const PATH = '/../v2/finance';
+    public const ERROR_FIELD_NAME_IN_JSON = 'errors';
 
     public function getFinancialProductConfig(
         string $slug,
@@ -23,18 +25,8 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
 
         $response = $this->brighteApi->post(sprintf('%s/graphql', self::PATH), json_encode($body), '', [], true);
 
-        if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
-            $this->logGraphqlResponse(__FUNCTION__, $response);
-
-            return null;
-        }
-
-        $json = $response->getBody()->getContents();
-        $body = json_decode($json);
-
-        if (array_key_exists('errors', $body)) {
-            $this->logGraphqlResponse(__FUNCTION__, $response);
-
+        $body = $this->checkIfContainsError(__FUNCTION__, $response);
+        if ($body === null) {
             return null;
         }
 
@@ -126,19 +118,9 @@ GQL;
         ];
     
         $response = $this->brighteApi->post(sprintf('%s/graphql', self::PATH), json_encode($body), '', [], true);
-        
-        if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
-            $this->logGraphqlResponse(__FUNCTION__, $response);
 
-            return null;
-        }
-        
-        $json = $response->getBody()->getContents();
-        $body = json_decode($json);
-
-        if (array_key_exists('errors', $body)) {
-            $this->logGraphqlResponse(__FUNCTION__, $response);
-
+        $body = $this->checkIfContainsError(__FUNCTION__, $response);
+        if ($body === null) {
             return null;
         }
 
@@ -179,5 +161,24 @@ GQL;
         $config->invoiceRequired = $configuration->invoiceRequired;
         $config->manualSettlementRequired = $configuration->manualSettlementRequired;
         return $config;
+    }
+
+    private function checkIfContainsError(string $function, ResponseInterface $response)
+    {
+        if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
+            $this->logGraphqlResponse($function, $response);
+
+            return null;
+        }
+
+        $json = $response->getBody()->getContents();
+        $body = json_decode($json);
+
+        if (property_exists($body, self::ERROR_FIELD_NAME_IN_JSON)) {
+            $this->logGraphqlResponse($function, $response);
+
+            return null;
+        }
+        return $body;
     }
 }

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -24,13 +24,20 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
         $response = $this->brighteApi->post(sprintf('%s/graphql', self::PATH), json_encode($body), '', [], true);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
-            $this->logResponse(__FUNCTION__, $response);
+            $this->logGraphqlResponse(__FUNCTION__, $response);
 
             return null;
         }
 
         $json = $response->getBody()->getContents();
         $body = json_decode($json);
+
+        if (array_key_exists('errors', $body)) {
+            $this->logGraphqlResponse(__FUNCTION__, $response);
+
+            return null;
+        }
+
         $data = $body->data->financialProductConfiguration;
 
         return $this->getFinancialProductConfigFromResponse($data);
@@ -121,13 +128,20 @@ GQL;
         $response = $this->brighteApi->post(sprintf('%s/graphql', self::PATH), json_encode($body), '', [], true);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
-            $this->logResponse(__FUNCTION__, $response);
+            $this->logGraphqlResponse(__FUNCTION__, $response);
 
             return null;
         }
         
         $json = $response->getBody()->getContents();
         $body = json_decode($json);
+
+        if (array_key_exists('errors', $body)) {
+            $this->logGraphqlResponse(__FUNCTION__, $response);
+
+            return null;
+        }
+
         $data = $body->data->financialProduct;
         
         $product = new FinancialProduct();

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -214,17 +214,18 @@ GQL;
     */
     public function testgetFinancialProductConfigFailWhenFinanceCoreReturnsError(): void
     {
+        $message = "Financial product configuration not found for slug" .
+        " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'";
+
         $body = [
             "errors" => [
                 [
-                    "message" => "Financial product configuration not found for slug" .
-                    " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                    "message" => $message,
                     "extensions" => [
                         "code" => "404",
                         "response" => [
                             "statusCode" => 404,
-                            "message" => "Financial product configuration not found for slug" .
-                            " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                            "message" => $message,
                             "error" => "Not Found",
                         ]
                     ]
@@ -235,9 +236,27 @@ GQL;
         $response = new Response(200, [], json_encode($body));
 
         $this->logger->expects(self::once())->method('warning')->with(
-            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: " .
-            "Financial product configuration not found for slug" .
-            " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'"
+            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: " . $message
+        );
+        $this->brighteApi->expects(self::once())->method('post')
+        ->with(self::PATH)->willReturn($response);
+        $config = $this->financeCoreApi->getFinancialProductConfig('slug');
+        self::assertNull($config);
+    }
+
+    /**
+    * @covers ::__construct
+    * @covers ::getFinancialProductConfig
+    * @covers ::createGetFinancialProductConfigQuery
+    * @covers ::checkIfContainsError
+    * @covers ::logGraphqlResponse
+    */
+    public function testgetFinancialProductConfigFailWhenServerError(): void
+    {
+        $response = new Response(504, [], json_encode(['message' => 'Gateway Time-out']));
+
+        $this->logger->expects(self::once())->method('warning')->with(
+            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 504: Gateway Time-out"
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);
@@ -253,15 +272,16 @@ GQL;
     */
     public function testgetFinancialProductFail(): void
     {
+        $message = "Financial product not found for slug 'brighte-green-loan-energy'";
         $body = [
             "errors" => [
                 [
-                    "message" => "Product not found for slug 'brighte-green-loan-energy'",
+                    "message" => $message,
                     "extensions" => [
                         "code" => "404",
                         "response" => [
                             "statusCode" => 404,
-                            "message" => "Product not found for slug 'brighte-green-loan-energy'",
+                            "message" => $message,
                             "error" => "Not Found",
                         ]
                     ]
@@ -273,12 +293,30 @@ GQL;
         $response = new Response(200, [], json_encode($body));
 
         $this->logger->expects(self::once())->method('warning')->with(
-            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: " .
-            "Product not found for slug 'brighte-green-loan-energy'"
+            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: " . $message
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);
         $product = $this->financeCoreApi->getFinancialProduct('slug');
         self::assertNull($product);
+    }
+
+    /**
+    * @covers ::__construct
+    * @covers ::getFinancialProduct
+    * @covers ::checkIfContainsError
+    * @covers ::logGraphqlResponse
+    */
+    public function testgetFinancialProductFailWhenServerError(): void
+    {
+        $response = new Response(503, [], json_encode(['message' => 'Service Unavailable']));
+
+        $this->logger->expects(self::once())->method('warning')->with(
+            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 503: Service Unavailable"
+        );
+        $this->brighteApi->expects(self::once())->method('post')
+        ->with(self::PATH)->willReturn($response);
+        $config = $this->financeCoreApi->getFinancialProduct('slug');
+        self::assertNull($config);
     }
 }

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -216,24 +216,7 @@ GQL;
     {
         $message = "Financial product configuration not found for slug" .
         " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'";
-
-        $body = [
-            "errors" => [
-                [
-                    "message" => $message,
-                    "extensions" => [
-                        "code" => "404",
-                        "response" => [
-                            "statusCode" => 404,
-                            "message" => $message,
-                            "error" => "Not Found",
-                        ]
-                    ]
-                ]
-            ],
-            "data" => null,
-        ];
-        $response = new Response(200, [], json_encode($body));
+        $response = $this->createGraphqlErrorResponse($message);
 
         $this->logger->expects(self::once())->method('warning')->with(
             "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: " . $message
@@ -273,24 +256,7 @@ GQL;
     public function testgetFinancialProductFail(): void
     {
         $message = "Financial product not found for slug 'brighte-green-loan-energy'";
-        $body = [
-            "errors" => [
-                [
-                    "message" => $message,
-                    "extensions" => [
-                        "code" => "404",
-                        "response" => [
-                            "statusCode" => 404,
-                            "message" => $message,
-                            "error" => "Not Found",
-                        ]
-                    ]
-                ]
-            ],
-            "data" => null,
-        ];
-
-        $response = new Response(200, [], json_encode($body));
+        $response = $this->createGraphqlErrorResponse($message);
 
         $this->logger->expects(self::once())->method('warning')->with(
             "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: " . $message
@@ -318,5 +284,27 @@ GQL;
         ->with(self::PATH)->willReturn($response);
         $config = $this->financeCoreApi->getFinancialProduct('slug');
         self::assertNull($config);
+    }
+
+    private function createGraphqlErrorResponse(string $message)
+    {
+        $body = [
+            "errors" => [
+                [
+                    "message" => $message,
+                    "extensions" => [
+                        "code" => "404",
+                        "response" => [
+                            "statusCode" => 404,
+                            "message" => $message,
+                            "error" => "Not Found",
+                        ]
+                    ]
+                ]
+            ],
+            "data" => null,
+        ];
+
+        return new Response(200, [], json_encode($body));
     }
 }

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -97,6 +97,7 @@ class FinanceCoreApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::getFinancialProductConfig
      * @covers ::getFinancialProductConfigFromResponse
      * @covers ::createGetFinancialProductConfigQuery
+     * @covers ::checkIfContainsError
      * @dataProvider financialProductConfigProvider
      */
     public function testgetFinancialProductConfig($input, $response): void
@@ -123,6 +124,7 @@ class FinanceCoreApiTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::__construct
      * @covers ::getFinancialProduct
+     * @covers ::checkIfContainsError
      * @covers ::getFinancialProductConfigFromResponse
      */
     public function testgetFinancialProduct(): void
@@ -207,6 +209,7 @@ GQL;
     * @covers ::__construct
     * @covers ::getFinancialProductConfig
     * @covers ::createGetFinancialProductConfigQuery
+    * @covers ::checkIfContainsError
     * @covers ::logGraphqlResponse
     */
     public function testgetFinancialProductConfigFailWhenFinanceCoreReturnsError(): void
@@ -214,12 +217,14 @@ GQL;
         $body = [
             "errors" => [
                 [
-                    "message" => "Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                    "message" => "Financial product configuration not found for slug" .
+                    " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
                     "extensions" => [
                         "code" => "404",
                         "response" => [
                             "statusCode" => 404,
-                            "message" => "Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                            "message" => "Financial product configuration not found for slug" .
+                            " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
                             "error" => "Not Found",
                         ]
                     ]
@@ -230,7 +235,9 @@ GQL;
         $response = new Response(200, [], json_encode($body));
 
         $this->logger->expects(self::once())->method('warning')->with(
-            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'"
+            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: " .
+            "Financial product configuration not found for slug" .
+            " 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'"
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);
@@ -241,6 +248,7 @@ GQL;
     /**
     * @covers ::__construct
     * @covers ::getFinancialProduct
+    * @covers ::checkIfContainsError
     * @covers ::logGraphqlResponse
     */
     public function testgetFinancialProductFail(): void
@@ -265,7 +273,8 @@ GQL;
         $response = new Response(200, [], json_encode($body));
 
         $this->logger->expects(self::once())->method('warning')->with(
-            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: Product not found for slug 'brighte-green-loan-energy'"
+            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: " .
+            "Product not found for slug 'brighte-green-loan-energy'"
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -207,13 +207,30 @@ GQL;
     * @covers ::__construct
     * @covers ::getFinancialProductConfig
     * @covers ::createGetFinancialProductConfigQuery
-    * @covers ::logResponse
+    * @covers ::logGraphqlResponse
     */
-    public function testgetFinancialProductConfigFail(): void
+    public function testgetFinancialProductConfigFailWhenFinanceCoreReturnsError(): void
     {
-        $response = new Response(404, [], json_encode(['message' => 'Not found']));
+        $body = [
+            "errors" => [
+                [
+                    "message" => "Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                    "extensions" => [
+                        "code" => "404",
+                        "response" => [
+                            "statusCode" => 404,
+                            "message" => "Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'",
+                            "error" => "Not Found",
+                        ]
+                    ]
+                ]
+            ],
+            "data" => null,
+        ];
+        $response = new Response(200, [], json_encode($body));
+
         $this->logger->expects(self::once())->method('warning')->with(
-            'BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 404: Not found'
+            "BrighteCapital\Api\AbstractApi->getFinancialProductConfig: 200: Financial product configuration not found for slug 'brighte-green-loan-energy', version 1 and vendorPublicId 'E81'"
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);
@@ -224,13 +241,31 @@ GQL;
     /**
     * @covers ::__construct
     * @covers ::getFinancialProduct
-    * @covers ::logResponse
+    * @covers ::logGraphqlResponse
     */
     public function testgetFinancialProductFail(): void
     {
-        $response = new Response(404, [], json_encode(['message' => 'Not found']));
+        $body = [
+            "errors" => [
+                [
+                    "message" => "Product not found for slug 'brighte-green-loan-energy'",
+                    "extensions" => [
+                        "code" => "404",
+                        "response" => [
+                            "statusCode" => 404,
+                            "message" => "Product not found for slug 'brighte-green-loan-energy'",
+                            "error" => "Not Found",
+                        ]
+                    ]
+                ]
+            ],
+            "data" => null,
+        ];
+
+        $response = new Response(200, [], json_encode($body));
+
         $this->logger->expects(self::once())->method('warning')->with(
-            'BrighteCapital\Api\AbstractApi->getFinancialProduct: 404: Not found'
+            "BrighteCapital\Api\AbstractApi->getFinancialProduct: 200: Product not found for slug 'brighte-green-loan-energy'"
         );
         $this->brighteApi->expects(self::once())->method('post')
         ->with(self::PATH)->willReturn($response);


### PR DESCRIPTION
Since graphql always return 200 status code, we need to check if there's an `errors` key in the json payload.