### PR TITLE
chore: move vlucas php dot env to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5",
         "squizlabs/php_codesniffer": "3.5",
-        "pact-foundation/pact-php": "^6.0.0"
+        "pact-foundation/pact-php": "^6.0.0",
+        "vlucas/phpdotenv": "^5.4"
     },
     "license": "MIT",
     "authors": [
@@ -25,8 +26,7 @@
         "cache/adapter-common": "^1.2",
         "fig/http-message-util": "^1.1",
         "guzzlehttp/psr7": "^1.6",
-        "netresearch/jsonmapper": "^3.1",
-        "vlucas/phpdotenv": "^5.4"
+        "netresearch/jsonmapper": "^3.1"
     },
     "scripts": {
         "cs": "phpcs -p",


### PR DESCRIPTION
This is not required for use, and conflicts with other packages such as slim core