### PR TITLE
chore: only load.environment in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,14 @@
     "autoload": {
         "psr-4": {
             "BrighteCapital\\Api\\": "src"
-        },
-        "files": ["load.environment.php"]
+        }
     },
     "autoload-dev": {
         "psr-4": {
             "BrighteCapital\\Api\\Tests\\": "tests"
-        }
+        },
+        "files": [
+            "load.environment.php"
+        ]
     }
 }


### PR DESCRIPTION
this load.environment script is running in production, which is undesirable