### PR TITLE
feat(GROW-236): add UID to get user api

### DIFF
--- a/src/IdentityApi.php
+++ b/src/IdentityApi.php
@@ -35,6 +35,7 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
         $user->email = $result->email ?? null;
         $user->phone = $result->phone ?? null;
         $user->sfContactId = $result->sfContactId ?? null;
+        $user->uid = $result->uid ?? null;
 
         return $user;
     }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -30,4 +30,7 @@ class User
 
     /** @var string Salesforce Contact ID */
     public $sfContactId;
+
+    /** @var string Universal ID */
+    public $uid;
 }

--- a/tests/IdentityApiTest.php
+++ b/tests/IdentityApiTest.php
@@ -51,6 +51,7 @@ class IdentityApiTest extends \PHPUnit\Framework\TestCase
             'phone' => '0412312412',
             'role' => 'CONSUMER',
             'sfContactId' => 'salesforce-contact-id',
+            'uid' => 'universal-id',
         ];
         $response = new Response(200, [], json_encode($providedUser));
         $this->brighteApi->expects(self::once())->method('get')
@@ -65,6 +66,7 @@ class IdentityApiTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('0412312412', $user->phone);
         self::assertEquals('CONSUMER', $user->role);
         self::assertEquals('salesforce-contact-id', $user->sfContactId);
+        self::assertEquals('universal-id', $user->uid);
     }
 
     /**


### PR DESCRIPTION
We need to have get-user API responded with Universal ID from `ms-identity`.