### PR TITLE
feat(SHLD-639) update get manufacturers methods

### DIFF
--- a/src/VendorApi.php
+++ b/src/VendorApi.php
@@ -163,15 +163,58 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
     }
 
     /**
-     * @param int $vendorId
-     * @return \BrighteCapital\Api\Models\Manufacturer[]
+     * @param int $manufacturerId
+     * @return \BrighteCapital\Api\Models\Manufacturer
      */
-    public function getManufacturers(int $categoryId): array
+    public function getManufacturerById(int $manufacturerId): Manufacturer
     {
-        $response = $this->brighteApi->get("/manufacturers/" . (string) $categoryId);
+        $response = $this->brighteApi->get("/manufacturers/" . (string) $manufacturerId);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
+
+            return null;
+        }
+
+        $result = json_decode((string) $response->getBody());
+        $manufacturer = new Manufacturer();
+        $manufacturer->id = $result->id;
+        $manufacturer->name = $result->name;
+        $manufacturer->description = $result->description;
+        $manufacturer->icon = $result->icon;
+        $manufacturer->slug = $result->slug;
+        $manufacturer->premium = $result->premium;
+
+        return $manufacturer;
+    }
+
+    /**
+     * @param string $categorySlug
+     * @return \BrighteCapital\Api\Models\Manufacturer[]
+     */
+    public function getManufacturersByCategory(string $categorySlug): array
+    {
+        return $this->retrieveManufacturers("/manufacturers?category=" . $categorySlug);
+    }
+    
+    /**
+     * @return \BrighteCapital\Api\Models\Manufacturer[]
+     */
+    public function getManufacturers(): array
+    {
+        return $this->retrieveManufacturers("/manufacturers");
+    }
+
+    /**
+     * @param string $queryPath
+     * @return \BrighteCapital\Api\Models\Manufacturer[]
+     */
+    private function retrieveManufacturers(string $queryPath): array
+    {
+        $response = $this->brighteApi->get($queryPath);
+
+        if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
+            $this->logResponse(debug_backtrace()[1]['function'], $response);
 
             return [];
         }

--- a/src/VendorApi.php
+++ b/src/VendorApi.php
@@ -166,7 +166,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      * @param int $manufacturerId
      * @return \BrighteCapital\Api\Models\Manufacturer
      */
-    public function getManufacturerById(int $manufacturerId): Manufacturer
+    public function getManufacturerById(int $manufacturerId): ?Manufacturer
     {
         $response = $this->brighteApi->get("/manufacturers/" . (string) $manufacturerId);
 

--- a/tests/VendorApiTest.php
+++ b/tests/VendorApiTest.php
@@ -354,6 +354,22 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getManufacturerById
+     * @covers ::logResponse
+     */
+    public function testGetManufacturerByIdFail(): void
+    {
+        $response = new Response(404, [], json_encode(['message' => 'Not found']));
+        $this->logger->expects(self::once())->method('warning')->with(
+            'BrighteCapital\Api\AbstractApi->getManufacturerById: 404: Not found'
+        );
+        $this->brighteApi->method('get')->willReturn($response);
+        $manufacturer = $this->vendorApi->getManufacturerById(1);
+        self::assertNull($manufacturer);
+    }
+
+    /**
+     * @covers ::__construct
      * @covers ::getVendorPromos
      */
     public function testGetVendorPromos(): void

--- a/tests/VendorApiTest.php
+++ b/tests/VendorApiTest.php
@@ -256,6 +256,33 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getManufacturerById
+     */
+    public function testGetManufacturerById(): void
+    {
+        $providedVendor = [
+            'id' => 1,
+            'name' => 'Brighte Solar',
+            'description' => 'Brighte Solar',
+            'icon' => 'brighte.jpg',
+            'slug' => 'brighte-solar',
+            'premium' => true,
+        ];
+        
+        $response = new Response(200, [], json_encode($providedVendor));
+        $this->brighteApi->expects(self::once())->method('get')->with(
+            '/manufacturers/' . $providedVendor['id']
+        )->willReturn($response);
+        $manufacturer = $this->vendorApi->getManufacturerById($providedVendor['id']);
+        self::assertInstanceOf(Manufacturer::class, $manufacturer);
+        self::assertEquals(1, $manufacturer->id);
+        self::assertEquals('Brighte Solar', $manufacturer->name);
+        self::assertEquals('brighte-solar', $manufacturer->slug);
+        self::assertEquals(true, $manufacturer->premium);
+    }
+
+    /**
+     * @covers ::__construct
      * @covers ::getManufacturers
      */
     public function testGetManufacturers(): void
@@ -269,8 +296,35 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
             'premium' => true,
         ];
         $response = new Response(200, [], json_encode([$providedVendor]));
-        $this->brighteApi->expects(self::once())->method('get')->with('/manufacturers/1')->willReturn($response);
+        $this->brighteApi->expects(self::once())->method('get')->with('/manufacturers')->willReturn($response);
         $manufacturers = $this->vendorApi->getManufacturers(1);
+        self::assertCount(1, $manufacturers);
+        self::assertInstanceOf(Manufacturer::class, $manufacturers[1]);
+        self::assertEquals(1, $manufacturers[1]->id);
+        self::assertEquals('Brighte Solar', $manufacturers[1]->name);
+        self::assertEquals('brighte-solar', $manufacturers[1]->slug);
+        self::assertEquals(true, $manufacturers[1]->premium);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getManufacturersByCategory
+     */
+    public function testGetManufacturersByCategory(): void
+    {
+        $providedVendor = [
+            'id' => 1,
+            'name' => 'Brighte Solar',
+            'description' => 'Brighte Solar',
+            'icon' => 'brighte.jpg',
+            'slug' => 'brighte-solar',
+            'premium' => true,
+        ];
+        $response = new Response(200, [], json_encode([$providedVendor]));
+        $this->brighteApi->expects(self::once())->method('get')->with(
+            '/manufacturers?category=' . $providedVendor['slug']
+        )->willReturn($response);
+        $manufacturers = $this->vendorApi->getManufacturersByCategory($providedVendor['slug']);
         self::assertCount(1, $manufacturers);
         self::assertInstanceOf(Manufacturer::class, $manufacturers[1]);
         self::assertEquals(1, $manufacturers[1]->id);
@@ -291,7 +345,7 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
             'BrighteCapital\Api\AbstractApi->getManufacturers: 404: Not found'
         );
         $this->brighteApi->method('get')->willReturn($response);
-        $manufacturers = $this->vendorApi->getManufacturers(1);
+        $manufacturers = $this->vendorApi->getManufacturers();
         self::assertCount(0, $manufacturers);
     }
 

--- a/tests/VendorApiTest.php
+++ b/tests/VendorApiTest.php
@@ -284,6 +284,7 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::__construct
      * @covers ::getManufacturers
+     * @covers ::retrieveManufacturers
      */
     public function testGetManufacturers(): void
     {
@@ -309,6 +310,7 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::__construct
      * @covers ::getManufacturersByCategory
+     * @covers ::retrieveManufacturers
      */
     public function testGetManufacturersByCategory(): void
     {
@@ -337,6 +339,7 @@ class VendorApiTest extends \PHPUnit\Framework\TestCase
      * @covers ::__construct
      * @covers ::getManufacturers
      * @covers ::logResponse
+     * @covers ::retrieveManufacturers
      */
     public function testGetManufacturersFail(): void
     {


### PR DESCRIPTION
Reasons to change:
getManufacturers was added by passing a categoryId, however, ms-vendor requires the category slug to list the manufacturers.

What are the changes:
1. Add getManufacturerById
2. Add getManufacturersByCategorySlug
3. Update getManufacturers