### PR TITLE
feat(SHLD-710): add finance core vendor query

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -4,12 +4,83 @@ declare(strict_types=1);
 
 namespace BrighteCapital\Api;
 
+use BrighteCapital\Api\Models\FinanceCore\Vendor as FinanceCoreVendor;
+use BrighteCapital\Api\Models\FinanceCore\VendorRebate;
 use BrighteCapital\Api\Models\FinancialProductConfig;
 use BrighteCapital\Api\Models\FinancialProduct;
+use BrighteCapital\Api\Models\Vendor;
 
 class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
 {
     public const PATH = '/../v2/finance';
+
+    public function getVendor(
+        string $vendorId
+    ): ?FinanceCoreVendor {
+        $requestBody = [
+            'query' => $this->createGetVendorQuery($vendorId),
+        ];
+
+        $responseBody = $this->brighteApi->cachedPost(
+            __FUNCTION__,
+            func_get_args(),
+            sprintf('%s/graphql', self::PATH),
+            json_encode($requestBody),
+            '',
+            [],
+            true
+        );
+
+        if ($responseBody == null) {
+            return null;
+        }
+        $data = $responseBody->data->vendor;
+
+        return $this->getVendorFromResponse($data);
+    }
+
+    public function createGetVendorQuery(
+        string $vendorId
+    ): string {
+        $queryParameter = "publicId: \"{$vendorId}\"";
+
+        return <<<GQL
+        query {
+            vendor (filter: { $queryParameter }) {
+              legacyId
+              publicId
+              tradingName
+              sfAccountId
+              slug
+              activeRebate {
+                startDate
+                finishDate
+                dollar
+                percentage
+              }
+            }
+          }
+GQL;
+    }
+
+    private function getVendorFromResponse($data): FinanceCoreVendor
+    {
+        $vendor = new FinanceCoreVendor();
+        $vendor->legacyId = $data->legacyId;
+        $vendor->publicId = $data->publicId;
+        $vendor->tradingName = $data->tradingName;
+        $vendor->sfAccountId = $data->sfAccountId;
+        $vendor->slug = $data->slug;
+        if ($data->activeRebate !== null) {
+            $vendor->activeRebate = new VendorRebate();
+            $vendor->activeRebate->startDate = $data->activeRebate->startDate;
+            $vendor->activeRebate->finishDate = $data->activeRebate->finishDate;
+            $vendor->activeRebate->dollar = $data->activeRebate->dollar;
+            $vendor->activeRebate->percentage = $data->activeRebate->percentage;
+        }
+        
+        return $vendor;
+    }
 
     public function getFinancialProductConfig(
         string $slug,

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -8,11 +8,10 @@ use BrighteCapital\Api\Models\FinanceCore\Vendor as FinanceCoreVendor;
 use BrighteCapital\Api\Models\FinanceCore\VendorRebate;
 use BrighteCapital\Api\Models\FinancialProductConfig;
 use BrighteCapital\Api\Models\FinancialProduct;
-use BrighteCapital\Api\Models\Vendor;
 
 class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
 {
-    public const PATH = '/../v2/finance';
+    public const PATH = '/../v2/finance/graphql';
 
     public function getVendor(
         string $vendorId
@@ -24,7 +23,7 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
         $responseBody = $this->brighteApi->cachedPost(
             __FUNCTION__,
             func_get_args(),
-            sprintf('%s/graphql', self::PATH),
+            self::PATH,
             json_encode($requestBody),
             '',
             [],
@@ -94,7 +93,7 @@ GQL;
         $responseBody = $this->brighteApi->cachedPost(
             __FUNCTION__,
             func_get_args(),
-            sprintf('%s/graphql', self::PATH),
+            self::PATH,
             json_encode($requestBody),
             '',
             [],
@@ -194,7 +193,7 @@ GQL;
         $responseBody = $this->brighteApi->cachedPost(
             __FUNCTION__,
             func_get_args(),
-            sprintf('%s/graphql', self::PATH),
+            self::PATH,
             json_encode($requestBody),
             '',
             [],

--- a/src/Models/FinanceCore/Vendor.php
+++ b/src/Models/FinanceCore/Vendor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BrighteCapital\Api\Models\FinanceCore;
+
+class Vendor
+{
+
+    /** @var int Entity ID */
+    public $legacyId;
+
+    /** @var string Remote ID */
+    public $publicId;
+
+    /** @var string Trading Name */
+    public $tradingName;
+
+    /** @var string Salesforce Account ID */
+    public $sfAccountId;
+
+    /** @var string Slug */
+    public $slug;
+
+    /** @var VendorRebate Active Rebate */
+    public $activeRebate = null;
+}

--- a/src/Models/FinanceCore/VendorRebate.php
+++ b/src/Models/FinanceCore/VendorRebate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BrighteCapital\Api\Models\FinanceCore;
+
+class VendorRebate
+{
+
+    /** @var \DateTime Start Date */
+    public $startDate;
+
+    /** @var \DateTime Finish Date */
+    public $finishDate;
+
+    /** @var float Dollar */
+    public $dollar;
+
+    /** @var float Percentage */
+    public $percentage;
+}


### PR DESCRIPTION
Reasons for this change:

Ability to get the active rebate for a vendor
Gradually replace ms-vendor to finance-core query (e.g. ms-finance still uses ms-vendor to create the vendor object in the event payload)