### PR TITLE
feat(SHLD-710): use filter on vendor query

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -45,7 +45,8 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
     public function createGetVendorQuery(
         array $filter
     ): string {
-        $field = array_key_first($filter);
+        reset($filter);
+        $field = key($filter);
         $value = $filter[$field];
         $queryParameter = "{$field}: \"{$value}\"";
         

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -47,8 +47,9 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
     ): string {
         reset($filter);
         $field = key($filter);
-        $value = $filter[$field];
-        $queryParameter = "{$field}: \"{$value}\"";
+        $value = is_string($filter[$field]) ? "\"{$filter[$field]}\"" : $filter[$field];
+
+        $queryParameter = "{$field}: {$value}";
         
         return <<<GQL
         query {

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -14,10 +14,14 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
     public const PATH = '/../v2/finance/graphql';
 
     public function getVendor(
-        string $vendorId
+        array $filter = []
     ): ?FinanceCoreVendor {
+        if (!$filter) {
+            return null;
+        }
+
         $requestBody = [
-            'query' => $this->createGetVendorQuery($vendorId),
+            'query' => $this->createGetVendorQuery($filter),
         ];
 
         $responseBody = $this->brighteApi->cachedPost(
@@ -39,10 +43,12 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
     }
 
     public function createGetVendorQuery(
-        string $vendorId
+        array $filter
     ): string {
-        $queryParameter = "publicId: \"{$vendorId}\"";
-
+        $field = array_key_first($filter);
+        $value = $filter[$field];
+        $queryParameter = "{$field}: \"{$value}\"";
+        
         return <<<GQL
         query {
             vendor (filter: { $queryParameter }) {

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -290,7 +290,7 @@ GQL;
     public function testGetVendorWhenReturnsNull(): void
     {
         $filter = [
-            'publicId' => $this->expectedVendor['publicId']
+            'legacyId' => $this->expectedVendor['legacyId']
         ];
         $this->brighteApi
             ->expects(self::once())->method('cachedPost')

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -263,18 +263,20 @@ GQL;
      */
     public function testGetVendor(): void
     {
-        $vendorId = $this->expectedVendor['publicId'];
+        $filter = [
+            'publicId' => $this->expectedVendor['publicId']
+        ];
         $response = $this->expectedVendorResponse;
-        $query = $this->financeCoreApi->createGetVendorQuery($vendorId);
+        $query = $this->financeCoreApi->createGetVendorQuery($filter);
 
         $expectedBody = [
             'query' => $query
         ];
 
         $this->brighteApi->expects(self::once())->method('cachedPost')
-            ->with('getVendor', [$vendorId], self::PATH, json_encode($expectedBody))
+            ->with('getVendor', [$filter], self::PATH, json_encode($expectedBody))
             ->willReturn(json_decode(json_encode($response)));
-        $vendor = $this->financeCoreApi->getVendor($vendorId);
+        $vendor = $this->financeCoreApi->getVendor($filter);
         self::assertInstanceOf(FinanceCoreVendor::class, $vendor);
         self::assertEquals($this->expectedVendor, (array)$vendor);
     }
@@ -287,11 +289,18 @@ GQL;
      */
     public function testGetVendorWhenReturnsNull(): void
     {
-        $vendorId = $this->expectedVendor['publicId'];
+        $filter = [
+            'publicId' => $this->expectedVendor['publicId']
+        ];
         $this->brighteApi
             ->expects(self::once())->method('cachedPost')
             ->willReturn(null);
-        $vendor = $this->financeCoreApi->getVendor($vendorId);
+        $vendor = $this->financeCoreApi->getVendor($filter);
+        self::assertNull($vendor);
+
+        $this->brighteApi
+            ->expects(self::never())->method('cachedPost');
+        $vendor = $this->financeCoreApi->getVendor();
         self::assertNull($vendor);
     }
 }


### PR DESCRIPTION
**Reasons for this change:**

Allow dynamic filtering on Vendor query, instead of hardcoding it to only filter by `public_id`.
In ms-finance, the Application entity only store the vendor's `legacy_id`.
In portal, we can retrieve either the `legacy_id` or `public_id`.
