### PR TITLE
fix(SHLD-710): add getVendorByLegacyId

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -16,8 +16,9 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
     public function getVendor(
         string $vendorId
     ): ?FinanceCoreVendor {
+        $queryParameter = "publicId: \"{$vendorId}\"";
         $requestBody = [
-            'query' => $this->createGetVendorQuery($vendorId),
+            'query' => $this->createGetVendorQuery($queryParameter),
         ];
 
         $responseBody = $this->brighteApi->cachedPost(
@@ -38,11 +39,35 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
         return $this->getVendorFromResponse($data);
     }
 
-    public function createGetVendorQuery(
-        string $vendorId
-    ): string {
-        $queryParameter = "publicId: \"{$vendorId}\"";
+    public function getVendorByLegacyId(
+        int $vendorLegacyId
+    ): ?FinanceCoreVendor {
+        $queryParameter = "legacyId: {$vendorLegacyId}";
+        $requestBody = [
+            'query' => $this->createGetVendorQuery($queryParameter),
+        ];
+        
+        $responseBody = $this->brighteApi->cachedPost(
+            __FUNCTION__,
+            func_get_args(),
+            self::PATH,
+            json_encode($requestBody),
+            '',
+            [],
+            true
+        );
 
+        if ($responseBody == null) {
+            return null;
+        }
+        $data = $responseBody->data->vendor;
+
+        return $this->getVendorFromResponse($data);
+    }
+
+    public function createGetVendorQuery(
+        string $queryParameter
+    ): string {
         return <<<GQL
         query {
             vendor (filter: { $queryParameter }) {

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -81,6 +81,7 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
                 finishDate
                 dollar
                 percentage
+                rebateType
               }
             }
           }
@@ -101,6 +102,7 @@ GQL;
             $vendor->activeRebate->finishDate = $data->activeRebate->finishDate;
             $vendor->activeRebate->dollar = $data->activeRebate->dollar;
             $vendor->activeRebate->percentage = $data->activeRebate->percentage;
+            $vendor->activeRebate->rebateType = $data->activeRebate->rebateType;
         }
         
         return $vendor;

--- a/src/Models/FinanceCore/VendorRebate.php
+++ b/src/Models/FinanceCore/VendorRebate.php
@@ -18,4 +18,7 @@ class VendorRebate
 
     /** @var float Percentage */
     public $percentage;
+
+    /** @var string Rebate Type */
+    public $rebateType;
 }

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -255,7 +255,7 @@ GQL;
         self::assertNull($config);
     }
 
-        /**
+    /**
      * @covers ::__construct
      * @covers ::getVendor
      * @covers ::getVendorFromResponse
@@ -265,7 +265,8 @@ GQL;
     {
         $vendorId = $this->expectedVendor['publicId'];
         $response = $this->expectedVendorResponse;
-        $query = $this->financeCoreApi->createGetVendorQuery($vendorId);
+        $queryParameter = "publicId: \"{$vendorId}\"";
+        $query = $this->financeCoreApi->createGetVendorQuery($queryParameter);
 
         $expectedBody = [
             'query' => $query
@@ -292,6 +293,47 @@ GQL;
             ->expects(self::once())->method('cachedPost')
             ->willReturn(null);
         $vendor = $this->financeCoreApi->getVendor($vendorId);
+        self::assertNull($vendor);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getVendorByLegacyId
+     * @covers ::getVendorFromResponse
+     * @covers ::createGetVendorQuery
+     */
+    public function testGetVendorByLegacyId(): void
+    {
+        $vendorLegacyId = $this->expectedVendor['legacyId'];
+        $response = $this->expectedVendorResponse;
+        $queryParameter = "legacyId: {$vendorLegacyId}";
+        $query = $this->financeCoreApi->createGetVendorQuery($queryParameter);
+
+        $expectedBody = [
+            'query' => $query
+        ];
+
+        $this->brighteApi->expects(self::once())->method('cachedPost')
+            ->with('getVendorByLegacyId', [$vendorLegacyId], self::PATH, json_encode($expectedBody))
+            ->willReturn(json_decode(json_encode($response)));
+        $vendor = $this->financeCoreApi->getVendorByLegacyId($vendorLegacyId);
+        self::assertInstanceOf(FinanceCoreVendor::class, $vendor);
+        self::assertEquals($this->expectedVendor, (array)$vendor);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getVendorByLegacyId
+     * @covers ::getVendorFromResponse
+     * @covers ::createGetVendorQuery
+     */
+    public function testGetVendorByLegacyIdWhenReturnsNull(): void
+    {
+        $legacyId = $this->expectedVendor['legacyId'];
+        $this->brighteApi
+            ->expects(self::once())->method('cachedPost')
+            ->willReturn(null);
+        $vendor = $this->financeCoreApi->getVendorByLegacyId($legacyId);
         self::assertNull($vendor);
     }
 }


### PR DESCRIPTION
This method will be use by ms-finance, as the Application entity only store the vendor's legacy_id.