### PR TITLE
fix(SHLD-826): fix String cannot represent a non string value

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -272,10 +272,11 @@ GQL;
 
     public function getFinanceAccount(string $id): ?Account
     {
+        $queryParameter = "id: \"{$id}\"";
         $query = <<<GQL
             query {
                 financeAccount(
-                id: {$id}
+                {$queryParameter}
                 ) {
                     id
                     vendorId

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -272,11 +272,10 @@ GQL;
 
     public function getFinanceAccount(string $id): ?Account
     {
-        $queryParameter = "id: \"{$id}\"";
         $query = <<<GQL
             query {
                 financeAccount(
-                {$queryParameter}
+                id: "{$id}"
                 ) {
                     id
                     vendorId

--- a/src/Models/FinanceCore/Account.php
+++ b/src/Models/FinanceCore/Account.php
@@ -19,7 +19,6 @@ class Account
     /** @var string Status */
     public $status;
 
-    /** @var VendorRebate[]  Rebates */
+    /** @var VendorRebate[] Rebates */
     public $rebates;
-
 }

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -372,10 +372,11 @@ GQL;
     public function testGetFinanceAccount(): void
     {
         $id = $this->expectedFinanceAccount['id'];
+        $queryParameter = "id: \"{$id}\"";
         $query = <<<GQL
             query {
                 financeAccount(
-                id: {$id}
+                {$queryParameter}
                 ) {
                     id
                     vendorId

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -372,11 +372,10 @@ GQL;
     public function testGetFinanceAccount(): void
     {
         $id = $this->expectedFinanceAccount['id'];
-        $queryParameter = "id: \"{$id}\"";
         $query = <<<GQL
             query {
                 financeAccount(
-                {$queryParameter}
+                id: "{$id}"
                 ) {
                     id
                     vendorId


### PR DESCRIPTION
Fix error 
> App\Gateway\LoanManagementGateway::performAction: Client error: `POST https://api.staging.cloud.brighte.com.au/v2/finance/graphql` resulted in a `400 Bad Request` response:
{"errors":[{"message":"String cannot represent a non string value: 27075","locations":[{"line":3,"column":21}],"extensio (truncated...)