### PR TITLE
fix(SHLD-826): remove vendorId and loanTypeId from account query

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -278,8 +278,6 @@ GQL;
                 id: "{$id}"
                 ) {
                     id
-                    vendorId
-                    loanTypeId
                     status
                     rebates {
                         startDate
@@ -318,8 +316,6 @@ GQL;
     {
         $account = new Account();
         $account->id = $data->id;
-        $account->vendorId = $data->vendorId;
-        $account->loanTypeId = $data->loanTypeId;
         $account->status = $data->status;
         if (count($data->rebates) > 0) {
             foreach ($data->rebates as $rebate) {

--- a/src/Models/FinanceCore/Account.php
+++ b/src/Models/FinanceCore/Account.php
@@ -10,12 +10,6 @@ class Account
     /** @var string Account ID */
     public $id;
 
-    /** @var int Loan Type Id */
-    public $loanTypeId;
-
-    /** @var int Vendor Id */
-    public $vendorId;
-
     /** @var string Status */
     public $status;
 

--- a/tests/FinanceCoreApiTest.php
+++ b/tests/FinanceCoreApiTest.php
@@ -93,8 +93,6 @@ class FinanceCoreApiTest extends \PHPUnit\Framework\TestCase
 
         $this->expectedFinanceAccount = [
             'id' => '1234',
-            'vendorId' => 1,
-            'loanTypeId' => 1,
             'status' => 'PENDING',
             'rebates' => [
                 [
@@ -378,8 +376,6 @@ GQL;
                 id: "{$id}"
                 ) {
                     id
-                    vendorId
-                    loanTypeId
                     status
                     rebates {
                         startDate


### PR DESCRIPTION
I forgot that the vendorId and loanTypeId are not exposed and has been moved to vendor and financialProduct. My bad that I didn't actually test the query in the playground.

Fix error:
> EMERGENCY: App\Gateway\LoanManagementGateway::performAction: Client error: `POST https://api.staging.cloud.brighte.com.au/v2/finance/graphql` resulted in a `400 Bad Request` response:
{"errors":[{"message":"Cannot query field \"vendorId\" on type \"Account\". Did you mean \"vendor\"?","locations":[{"lin (truncated...)
 {"exception":"Client error: `POST https:\/\/api.staging.cloud.brighte.com.au\/v2\/finance\/graphql` resulted in a `400 Bad Request` response:\n{\"errors\":[{\"message\":\"Cannot query field \\\"vendorId\\\" on type \\\"Account\\\". Did you mean \\\"vendor\\\"?\",\"locations\":[{\"lin (truncated...)\n","success":false,"method":"createLoanAccountFromMsFinance","scope":[]}

Removing the vendor and loanTypeId data, as it is not used.

Test:
![Screenshot 2022-12-14 at 12 35 27 pm](https://user-images.githubusercontent.com/20748317/207483401-94bc4a38-34c7-40af-8f03-eef15c3e04ed.png)

