### PR TITLE
NGMA-1060 adding quotes for string parameter

### DIFF
--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -141,7 +141,7 @@ GQL;
         string $vendorId = null,
         int $version = null
     ): string {
-        $queryParameter = "financialProductId: {$financialProductId}";
+        $queryParameter = "financialProductId: \"{$financialProductId}\"";
         if ($vendorId) {
             $queryParameter .= PHP_EOL . "vendorId: \"{$vendorId}\"";
         }


### PR DESCRIPTION
Adding quotes around financialProductId parameter as the query expects it to be string and it breaks without it.